### PR TITLE
Added ability to push packages to sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The Chocolatey Visual Studio Code provides the following commands:
 * `Chocolatey: Create new Chocolatey package` to create the default templated Chocolatey package at the root of current workspace.
 * `Chocolatey: Pack Chocolatey package(s)` to search current workspace for nuspec files and package them
 * `Chocolatey: Delete Chocolatey package(s)` to search current workspace for nupkg files and delete them
+* `Chocolatey: Push Chocolatey package(s)` to search current workspace for nupkg files and push them
 
 ## Snippets
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1905,6 +1905,11 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
 		"semver": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
@@ -2395,6 +2400,20 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
+		},
+		"xml2js": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+			"requires": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~9.0.1"
+			}
+		},
+		"xmlbuilder": {
+			"version": "9.0.7",
+			"resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		},
 		"xtend": {
 			"version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 	"activationEvents": [
 		"onCommand:chocolatey.new",
 		"onCommand:chocolatey.pack",
-		"onCommand:chocolatey.delete"
+		"onCommand:chocolatey.delete",
+		"onCommand:chocolatey.push"
 	],
 	"engines": {
 		"vscode": "^1.24.0"
@@ -46,6 +47,10 @@
 			{
 				"command": "chocolatey.delete",
 				"title": "Chocolatey: Delete Chocolatey package(s)"
+			},
+			{
+				"command": "chocolatey.push",
+				"title": "Chocolatey: Push Chocolatey package(s)"
 			}
 		],
 		"snippets": [
@@ -76,5 +81,8 @@
 		"typemoq": "^2.1.0",
 		"typescript": "^2.6.1",
 		"vscode": "^1.1.6"
+	},
+	"dependencies": {
+		"xml2js": "^0.4.19"
 	}
 }

--- a/src/ChocolateyCliManager.ts
+++ b/src/ChocolateyCliManager.ts
@@ -1,8 +1,13 @@
 import { window, QuickPickItem, workspace } from "vscode";
 import { ChocolateyOperation } from "./ChocolateyOperation";
 import * as path from "path";
+import * as xml2js from "xml2js";
+import * as fs from "fs";
+import { getPathToChocolateyConfig } from "./config";
 
 export class ChocolateyCliManager {
+
+
     public new(): void {
         window.showInputBox({
             prompt: "Name for new Chocolatey Package?"
@@ -68,6 +73,126 @@ export class ChocolateyCliManager {
                         // tslint:disable-next-line:max-line-length
                         let packOp: ChocolateyOperation = new ChocolateyOperation(["pack", nuspecSelection.label, additionalArguments], { isOutputChannelVisible: true, currentWorkingDirectory: cwd });
                         packOp.run();
+                    }
+                });
+            });
+        });
+    }
+
+    public push(): void {
+        // tslint:disable-next-line:max-line-length
+        function pushPackage(packages: Array<QuickPickItem>, selectedNupkg: QuickPickItem, allPackages: boolean, source: string, apikey: string): void {
+            window.showInputBox({
+                prompt: "Additional command arguments?"
+            }).then((additionalArguments) => {
+                let chocolateyArguments: string[] = [];
+                if(source) {
+                    chocolateyArguments.push("--source=\"'" + source + "'\"");
+                }
+
+                if(apikey) {
+                    chocolateyArguments.push("--api-key=\"'" + apikey + "'\"");
+                }
+
+                if(allPackages) {
+                    packages.forEach((packageToPush) => {
+                        if(!additionalArguments || additionalArguments === "") {
+                            additionalArguments = "";
+                        }
+
+                        let cwd: string = packageToPush.description ? packageToPush.description : "";
+                        chocolateyArguments.unshift(packageToPush.label);
+                        chocolateyArguments.unshift("push");
+                        chocolateyArguments.push(additionalArguments);
+
+                        // tslint:disable-next-line:max-line-length
+                        let pushOp: ChocolateyOperation = new ChocolateyOperation(chocolateyArguments, { isOutputChannelVisible: true, currentWorkingDirectory: cwd });
+                        pushOp.run();
+                    });
+                } else {
+                    if(!additionalArguments || additionalArguments === "") {
+                        additionalArguments = "";
+                    }
+                    let cwd: string = selectedNupkg.description ? selectedNupkg.description : "";
+                    chocolateyArguments.unshift(selectedNupkg.label);
+                    chocolateyArguments.unshift("push");
+                    chocolateyArguments.push(additionalArguments);
+
+                    // tslint:disable-next-line:max-line-length
+                    let pushOp: ChocolateyOperation = new ChocolateyOperation(chocolateyArguments, { isOutputChannelVisible: true, currentWorkingDirectory: cwd });
+                    pushOp.run();
+                }
+            });
+        }
+
+        workspace.findFiles("**/*.nupkg").then((nupkgFiles) => {
+            if(nupkgFiles.length ===0) {
+                window.showErrorMessage("There are no nupkg files in the current workspace.");
+                return;
+            }
+
+            let quickPickItems: Array<QuickPickItem> =  nupkgFiles.map((filePath) => {
+                return {
+                    label: path.basename(filePath.fsPath),
+                    description: path.dirname(filePath.fsPath)
+                };
+            });
+
+            if(quickPickItems.length > 1) {
+                quickPickItems.unshift({label: "All nupkg files"});
+            }
+
+            window.showQuickPick(quickPickItems, {
+                placeHolder: "Available nupkg files..."
+              }).then((nupkgSelection) => {
+                if(!nupkgSelection) {
+                    return;
+                }
+
+                let parser: xml2js.Parser = new xml2js.Parser();
+                const contents: string = fs.readFileSync(getPathToChocolateyConfig()).toString();
+                parser.parseString(contents, function(err: any, result: any): void {
+                    if(err) {
+                        console.log(err);
+                        return;
+                    }
+
+                    let sourceQuickPickItems: Array<QuickPickItem> = new Array<QuickPickItem>();
+
+                    result.chocolatey.sources[0].source.forEach((source  => {
+                        sourceQuickPickItems.push({
+                                label: source.$.id,
+                                description: source.$.value
+                            });console.log(source);
+                    }));
+
+                    if(sourceQuickPickItems.length === 0) {
+                        // need to get user to specify source
+                        window.showInputBox({
+                            prompt: "Source URL"
+                        }).then((specifiedSource) => {
+                            window.showInputBox({
+                                prompt: "API Key"
+                            }).then((specifiedApiKey) => {
+                                if(!specifiedSource || !specifiedApiKey) {
+                                    return;
+                                }
+
+                                // tslint:disable-next-line:max-line-length
+                                pushPackage(quickPickItems, nupkgSelection, nupkgSelection.label === "All nupkg files", specifiedSource, specifiedApiKey);
+                            });
+                        });
+                    } else {
+                        window.showQuickPick(sourceQuickPickItems, {
+                            placeHolder: "Select configured source..."
+                        }).then((sourceSelection) => {
+                            if(!sourceSelection || !sourceSelection.description) {
+                                return;
+                            }
+
+                            // tslint:disable-next-line:max-line-length
+                            pushPackage(quickPickItems, nupkgSelection, nupkgSelection.label === "All nupkg files", sourceSelection.description, "");
+                        });
                     }
                 });
             });

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,17 @@ export function getFullAppPath(): string {
     return "";
 }
 
+export function getPathToChocolateyConfig(): string {
+    let chocolateyInstallEnvironmentVariable: string | undefined = process.env.ChocolateyInstall;
+
+    if(chocolateyInstallEnvironmentVariable === undefined) {
+        // todo: this is really an error condition, and something should be done
+        return "";
+    }
+
+    return path.join(chocolateyInstallEnvironmentVariable, "config/chocolatey.config");
+}
+
 export function getPathToChocolateyBin(): string {
     let chocolateyInstallEnvironmentVariable: string | undefined = process.env.ChocolateyInstall;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ export function activate(): void {
     commands.registerCommand("chocolatey.new", () => execute("new"));
     commands.registerCommand("chocolatey.pack", () => execute("pack"));
     commands.registerCommand("chocolatey.delete", () => deleteNupkgs());
+    commands.registerCommand("chocolatey.push", () => execute("push"));
 }
 
 function deleteNupkgs():void {


### PR DESCRIPTION
This will allow the following:

- Allow selection of one, or all, nupkgs in current workspace for pushing
- Allow selection of pre-configured sources from chocolatey.config file, or input of a custom source
- If no pre-configured sources in chocolatey.config file, you will have to input source and optionally api key
- Also allow the input of additional arguments to command