### PR TITLE
(GH-104) Created base class for nuspec rules

### DIFF
--- a/src/Chocolatey.Language.Server/DiagnosticsHandler.cs
+++ b/src/Chocolatey.Language.Server/DiagnosticsHandler.cs
@@ -43,7 +43,8 @@ namespace Chocolatey.Language.Server
 
             foreach (var rule in _rules.OrEmptyListIfNull())
             {
-                diagnostics.AddRange(rule.Validate(syntaxTree, textPositions));
+                rule.SetTextPositions(textPositions);
+                diagnostics.AddRange(rule.Validate(syntaxTree));
             }
 
             _router.Document.PublishDiagnostics(new PublishDiagnosticsParams

--- a/src/Chocolatey.Language.Server/INuSpecRule.cs
+++ b/src/Chocolatey.Language.Server/INuSpecRule.cs
@@ -4,8 +4,25 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Chocolatey.Language.Server
 {
+    /// <summary>
+    /// Interface used to define common methods used when validation a nuspec file.
+    /// </summary>
     public interface INuSpecRule
     {
-        IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree, TextPositions textPositions);
+        /// <summary>
+        /// Sets the position of the currently used nuspec text.
+        /// </summary>
+        /// <param name="positions">The positions to use for the current text.</param>
+        /// <remarks>
+        ///   This should be set in <see cref="DiagnosticsHandler"/> before running the <see cref="Validate(XmlDocumentSyntax)"/> method.
+        /// </remarks>
+        void SetTextPositions(TextPositions positions);
+
+        /// <summary>
+        /// Runs validation of the current nuspec file by using the specified <paramref name="syntaxTree"/>.
+        /// </summary>
+        /// <param name="syntaxTree">The syntax tree to use during validation.</param>
+        /// <returns>An enumerable of failed checks</returns>
+        IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree);
     }
 }

--- a/src/Chocolatey.Language.Server/Validations/DescriptionLengthValidation.cs
+++ b/src/Chocolatey.Language.Server/Validations/DescriptionLengthValidation.cs
@@ -17,7 +17,7 @@ namespace Chocolatey.Language.Server.Validations
     {
         public override IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree)
         {
-            var descriptionElement = syntaxTree.DescendantNodes().OfType<XmlElementSyntax>().FirstOrDefault(x => string.Equals(x.Name, "description", StringComparison.OrdinalIgnoreCase));
+            var descriptionElement = FindElementByName(syntaxTree, "description");
 
             if (descriptionElement == null)
             {

--- a/src/Chocolatey.Language.Server/Validations/DescriptionLengthValidation.cs
+++ b/src/Chocolatey.Language.Server/Validations/DescriptionLengthValidation.cs
@@ -13,19 +13,20 @@ namespace Chocolatey.Language.Server.Validations
     /// <seealso href="https://github.com/chocolatey/package-validator/blob/master/src/chocolatey.package.validator/infrastructure.app/rules/DescriptionRequirement.cs">Package validator requirement for description.</seealso>
     /// <seealso href="https://github.com/chocolatey/package-validator/blob/master/src/chocolatey.package.validator/infrastructure.app/rules/DescriptionWordCountMaximum4000Requirement.cs">Package validator maximum length requirement for description.</seealso>
     /// <seealso href="https://github.com/chocolatey/package-validator/blob/master/src/chocolatey.package.validator/infrastructure.app/rules/DescriptionWordCountMinimum30Guideline.cs">Package validator minimum length guideline for description.</seealso>
-    public class DescriptionLengthValidation : INuSpecRule
+    public class DescriptionLengthValidation : NuspecRuleBase
     {
-        public IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree, TextPositions textPositions)
+        public override IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree)
         {
             var descriptionElement = syntaxTree.DescendantNodes().OfType<XmlElementSyntax>().FirstOrDefault(x => string.Equals(x.Name, "description", StringComparison.OrdinalIgnoreCase));
 
             if (descriptionElement == null)
             {
-                yield return new Diagnostic {
-                    Message = "Description is required. See https://github.com/chocolatey/package-validator/wiki/DescriptionNotEmpty",
-                    Severity = DiagnosticSeverity.Error,
-                    Range = textPositions.GetRange(0, syntaxTree.End)
-                };
+                yield return CreateDiagnostic(
+                    0,
+                    syntaxTree.End,
+                    DiagnosticSeverity.Error,
+                    "Description is required.",
+                    "https://github.com/chocolatey/package-validator/wiki/DescriptionNotEmpty");
                 yield break;
             }
 
@@ -33,33 +34,24 @@ namespace Chocolatey.Language.Server.Validations
 
             if (descriptionLength == 0)
             {
-                var range = textPositions.GetRange(descriptionElement.StartTag.End, descriptionElement.EndTag.Start);
-
-                yield return new Diagnostic {
-                    Message = "Description is required. See https://github.com/chocolatey/package-validator/wiki/DescriptionNotEmpty",
-                    Severity = DiagnosticSeverity.Error,
-                    Range = range
-                };
+                yield return CreateRequirement(
+                    descriptionElement,
+                    "Description is required.",
+                    "https://github.com/chocolatey/package-validator/wiki/DescriptionNotEmpty");
             }
             else if (descriptionLength <= 30)
             {
-                var range = textPositions.GetRange(descriptionElement.StartTag.End, descriptionElement.EndTag.Start);
-
-                yield return new Diagnostic {
-                    Message = "Description should be sufficient to explain the software. See https://github.com/chocolatey/package-validator/wiki/DescriptionCharacterCountMinimum",
-                    Severity = DiagnosticSeverity.Warning,
-                    Range = range
-                };
+                yield return CreateGuideline(
+                    descriptionElement,
+                    "Description should be sufficient to explain the software.",
+                    "https://github.com/chocolatey/package-validator/wiki/DescriptionCharacterCountMinimum");
             }
             else if (descriptionLength > 4000)
             {
-                var range = textPositions.GetRange(descriptionElement.StartTag.End, descriptionElement.EndTag.Start);
-
-                yield return new Diagnostic {
-                    Message = "Description should not exceed 4000 characters. See https://github.com/chocolatey/package-validator/wiki/DescriptionCharacterCountMaximum",
-                    Severity = DiagnosticSeverity.Error,
-                    Range = range
-                };
+                yield return CreateRequirement(
+                    descriptionElement,
+                    "Description should not exceed 4000 characters.",
+                    "https://github.com/chocolatey/package-validator/wiki/DescriptionCharacterCountMaximum");
             }
         }
     }

--- a/src/Chocolatey.Language.Server/Validations/DoesNotContainTemplatedVaules.cs
+++ b/src/Chocolatey.Language.Server/Validations/DoesNotContainTemplatedVaules.cs
@@ -11,7 +11,7 @@ namespace Chocolatey.Language.Server.Validations
     ///   Handler to validate that no templated values remain in the nuspec.
     /// </summary>
     /// <seealso href="https://github.com/chocolatey/package-validator/blob/master/src/chocolatey.package.validator/infrastructure.app/rules/NuspecDoesNotContainTemplatedValuesRequirement.cs">Package validator requirement for templated values.</seealso>
-    public class DoesNotContainTemplatedValues : INuSpecRule
+    public class DoesNotContainTemplatedValues : NuspecRuleBase
     {
         private static readonly IReadOnlyCollection<string> TemplatedValues = new []
         {
@@ -20,7 +20,7 @@ namespace Chocolatey.Language.Server.Validations
             "tag1"
         };
 
-        public IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree, TextPositions textPositions)
+        public override IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree)
         {
             foreach (var node in syntaxTree.DescendantNodesAndSelf().OfType<XmlTextSyntax>())
             {
@@ -29,13 +29,10 @@ namespace Chocolatey.Language.Server.Validations
                     continue;
                 }
 
-                var range = textPositions.GetRange(node.Start, node.End);
-
-                yield return new Diagnostic {
-                    Message = "Templated value which should be removed.  See https://github.com/chocolatey/package-validator/wiki/NuspecDoesNotContainTemplatedValues",
-                    Severity = DiagnosticSeverity.Error,
-                    Range = range
-                };
+                yield return CreateRequirement(
+                    node,
+                    "Templated value which should be removed.",
+                    "https://github.com/chocolatey/package-validator/wiki/NuspecDoesNotContainTemplatedValues");
             }
         }
     }

--- a/src/Chocolatey.Language.Server/Validations/NuspecRuleBase.cs
+++ b/src/Chocolatey.Language.Server/Validations/NuspecRuleBase.cs
@@ -1,0 +1,162 @@
+﻿using System.Collections.Generic;
+using Microsoft.Language.Xml;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using DiagnosticSeverity = OmniSharp.Extensions.LanguageServer.Protocol.Models.DiagnosticSeverity;
+
+namespace Chocolatey.Language.Server.Validations
+{
+    /// <summary>
+    /// The base class for making implemention of <see cref="INuSpecRule"/> easier.
+    /// </summary>
+    public abstract class NuspecRuleBase : INuSpecRule
+    {
+        private TextPositions _textPositions;
+
+        /// <summary>
+        /// Sets the position of the currently used nuspec text.
+        /// </summary>
+        /// <param name="positions">The positions to use for the current text.</param>
+        /// <remarks>
+        /// This should be set in <see cref="DiagnosticsHandler"/> before running the <see
+        /// cref="M:Chocolatey.Language.Server.Validations.NuspecRuleBase.Validate(XmlDocumentSyntax)"/> method.
+        /// </remarks>
+        public void SetTextPositions(TextPositions positions)
+            => _textPositions = positions;
+
+        /// <summary>
+        /// Runs validation of the current nuspec file by using the specified <paramref name="syntaxTree"/>.
+        /// </summary>
+        /// <param name="syntaxTree">The syntax tree to use during validation.</param>
+        /// <returns>An enumerable of failed checks</returns>
+        public abstract IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree);
+
+        #region Diagnostic creation helpers
+
+        /// <summary>
+        ///   Creates a single requirement diagnostic using the specified <paramref name="syntaxTree" />.
+        /// </summary>
+        /// <param name="elementSyntax">The element syntax.</param>
+        /// <param name="message">The message to show the user.</param>
+        /// <param name="wikiUrl">The wiki URL for the current rule.</param>
+        /// <returns>The requirement diagnostic.</returns>
+        protected Diagnostic CreateRequirement(XmlElementSyntax elementSyntax, string message, string wikiUrl = null)
+            => CreateDiagnostic(elementSyntax, DiagnosticSeverity.Error, message, wikiUrl);
+
+        /// <summary>
+        ///   Creates a single requirement diagnostic using the specified <paramref name="syntaxNode" />.
+        /// </summary>
+        /// <param name="syntaxNode">The syntax node.</param>
+        /// <param name="message">The message to show the user.</param>
+        /// <param name="wikiUrl">The wiki URL for the current rule.</param>
+        /// <returns>The requirement diagnostic.</returns>
+        protected Diagnostic CreateRequirement(SyntaxNode syntaxNode, string message, string wikiUrl = null)
+            => CreateDiagnostic(syntaxNode, DiagnosticSeverity.Error, message, wikiUrl);
+
+        /// <summary>
+        ///   Creates a single guideline diagnostic using the specified <paramref name="syntaxTree" />.
+        /// </summary>
+        /// <param name="elementSyntax">The element syntax.</param>
+        /// <param name="message">The message to show the user.</param>
+        /// <param name="wikiUrl">The wiki URL for the current rule.</param>
+        /// <returns>The requirement diagnostic.</returns>
+        protected Diagnostic CreateGuideline(XmlElementSyntax elementSyntax, string message, string wikiUrl = null)
+            => CreateDiagnostic(elementSyntax, DiagnosticSeverity.Warning, message, wikiUrl);
+
+        /// <summary>
+        ///   Creates a single guideline diagnostic using the specified <paramref name="syntaxNode" />.
+        /// </summary>
+        /// <param name="syntaxNode">The syntax node.</param>
+        /// <param name="message">The message to show the user.</param>
+        /// <param name="wikiUrl">The wiki URL for the current rule.</param>
+        /// <returns>The requirement diagnostic.</returns>
+        protected Diagnostic CreateGuideline(SyntaxNode syntaxNode, string message, string wikiUrl = null)
+            => CreateDiagnostic(syntaxNode, DiagnosticSeverity.Warning, message, wikiUrl);
+
+        /// <summary>
+        ///   Creates a single suggestion diagnostic using the specified <paramref name="syntaxTree" />.
+        /// </summary>
+        /// <param name="elementSyntax">The element syntax.</param>
+        /// <param name="message">The message to show the user.</param>
+        /// <param name="wikiUrl">The wiki URL for the current rule.</param>
+        /// <returns>The requirement diagnostic.</returns>
+        protected Diagnostic CreateSuggestion(XmlElementSyntax elementSyntax, string message, string wikiUrl = null)
+            => CreateDiagnostic(elementSyntax, DiagnosticSeverity.Information, message, wikiUrl);
+
+        /// <summary>
+        ///   Creates a single suggestion diagnostic using the specified <paramref name="syntaxNode" />.
+        /// </summary>
+        /// <param name="syntaxNode">The syntax node.</param>
+        /// <param name="message">The message to show the user.</param>
+        /// <param name="wikiUrl">The wiki URL for the current rule.</param>
+        /// <returns>The requirement diagnostic.</returns>
+        protected Diagnostic CreateSuggestion(SyntaxNode syntaxNode, string message, string wikiUrl = null)
+            => CreateDiagnostic(syntaxNode, DiagnosticSeverity.Information, message, wikiUrl);
+
+        /// <summary>
+        ///   Creates a single note diagnostic using the specified <paramref name="syntaxTree" />.
+        /// </summary>
+        /// <param name="elementSyntax">The element syntax.</param>
+        /// <param name="message">The message to show the user.</param>
+        /// <param name="wikiUrl">The wiki URL for the current rule.</param>
+        /// <returns>The requirement diagnostic.</returns>
+        protected Diagnostic CreateNote(XmlElementSyntax elementSyntax, string message, string wikiUrl = null)
+            => CreateDiagnostic(elementSyntax, DiagnosticSeverity.Hint, message, wikiUrl);
+
+        /// <summary>
+        ///   Creates a single note diagnostic using the specified <paramref name="syntaxNode" />.
+        /// </summary>
+        /// <param name="syntaxNode">The syntax node.</param>
+        /// <param name="message">The message to show the user.</param>
+        /// <param name="wikiUrl">The wiki URL for the current rule.</param>
+        /// <returns>The requirement diagnostic.</returns>
+        protected Diagnostic CreateNote(SyntaxNode syntaxNode, string message, string wikiUrl = null)
+            => CreateDiagnostic(syntaxNode, DiagnosticSeverity.Hint, message, wikiUrl);
+
+        /// <summary>
+        ///   Creates a single diagnostic with the specified <paramref name="severity"/> using the specified <paramref name="syntaxNode" />.
+        /// </summary>
+        /// <param name="elementSyntax">The element syntax.</param>
+        /// <param name="severity">The Diagnostic severity to show the user.</param>
+        /// <param name="message">The message to show the user.</param>
+        /// <param name="wikiUrl">The wiki URL for the current rule.</param>
+        /// <returns>The the created diagnostic.</returns>
+        protected Diagnostic CreateDiagnostic(XmlElementSyntax elementSyntax, DiagnosticSeverity severity, string message, string wikiUrl)
+            => CreateDiagnostic(elementSyntax.StartTag.End, elementSyntax.EndTag.Start, severity, message, wikiUrl);
+
+        /// <summary>
+        ///   Creates a single diagnostic with the specified <paramref name="severity"/> using the specified <paramref name="syntaxNode" />.
+        /// </summary>
+        /// <param name="syntaxNode">The syntax node.</param>
+        /// <param name="severity">The Diagnostic severity to show the user.</param>
+        /// <param name="message">The message to show the user.</param>
+        /// <param name="wikiUrl">The wiki URL for the current rule.</param>
+        /// <returns>The created diagnostic.</returns>
+        protected Diagnostic CreateDiagnostic(SyntaxNode syntaxNode, DiagnosticSeverity severity, string message, string wikiUrl)
+            => CreateDiagnostic(syntaxNode.Start, syntaxNode.End, severity, message, wikiUrl);
+
+        /// <summary>
+        /// Creates a single diagnostic with the specified <paramref name="severity"/>.
+        /// </summary>
+        /// <param name="start">The start of where the diagnostic should be displayed.</param>
+        /// <param name="end">The end of where the diagnostic should be displayed.</param>
+        /// <param name="severity">The Diagnostic severity to show the user.</param>
+        /// <param name="message">The message to show the user.</param>
+        /// <param name="wikiUrl">The wiki URL for the current rule.</param>
+        /// <returns>The created diagnostic.</returns>
+        protected virtual Diagnostic CreateDiagnostic(int start, int end, DiagnosticSeverity severity, string message, string wikiUrl)
+        {
+            string errorMessage = string.IsNullOrEmpty(wikiUrl) ?
+                                  message :
+                                  $"{message} See {wikiUrl}";
+
+            return new Diagnostic
+            {
+                Message = errorMessage,
+                Severity = severity,
+                Range = _textPositions.GetRange(start, end)
+            };
+        }
+
+        #endregion Diagnostic creation helpers
+    }
+}

--- a/src/Chocolatey.Language.Server/Validations/NuspecRuleBase.cs
+++ b/src/Chocolatey.Language.Server/Validations/NuspecRuleBase.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Language.Xml;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using DiagnosticSeverity = OmniSharp.Extensions.LanguageServer.Protocol.Models.DiagnosticSeverity;
@@ -29,6 +31,17 @@ namespace Chocolatey.Language.Server.Validations
         /// <param name="syntaxTree">The syntax tree to use during validation.</param>
         /// <returns>An enumerable of failed checks</returns>
         public abstract IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree);
+
+        /// <summary>
+        /// Finds a single element in the specified <paramref name="syntaxTree"/> by the name.
+        /// </summary>
+        /// <param name="syntaxTree">The syntax tree to find the element in.</param>
+        /// <param name="name">The name of the element.</param>
+        /// <returns>The element syntax if one is found; otherwise returns <c>null</c>.</returns>
+        protected XmlElementSyntax FindElementByName(XmlDocumentSyntax syntaxTree, string name)
+            => syntaxTree.DescendantNodes()
+                         .OfType<XmlElementSyntax>()
+                         .FirstOrDefault(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
 
         #region Diagnostic creation helpers
 

--- a/src/Chocolatey.Language.Server/Validations/UrlValidValidation.cs
+++ b/src/Chocolatey.Language.Server/Validations/UrlValidValidation.cs
@@ -30,7 +30,7 @@ namespace Chocolatey.Language.Server.Validations
         public override IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree)
         {
             foreach (var elementName in UrlElements) {
-                var element = syntaxTree.DescendantNodes().OfType<XmlElementSyntax>().FirstOrDefault(x => string.Equals(x.Name, elementName, StringComparison.OrdinalIgnoreCase));
+                var element = FindElementByName(syntaxTree, elementName);
                 if (element != null) {
                     var uriString = element.GetContentValue().Trim();
                     if (

--- a/src/Chocolatey.Language.Server/Validations/UrlValidValidation.cs
+++ b/src/Chocolatey.Language.Server/Validations/UrlValidValidation.cs
@@ -12,7 +12,7 @@ namespace Chocolatey.Language.Server.Validations
     ///   Handler to validate the length of description in the package metadata.
     /// </summary>
     /// TODO: Add <seealso> elements once PR is merged
-    public class UrlValidValidation : INuSpecRule
+    public class UrlValidValidation : NuspecRuleBase
     {
         private static readonly IReadOnlyCollection<string> UrlElements = new []
         {
@@ -27,25 +27,22 @@ namespace Chocolatey.Language.Server.Validations
             "wikiUrl",
         };
 
-        public IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree, TextPositions textPositions)
+        public override IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree)
         {
             foreach (var elementName in UrlElements) {
                 var element = syntaxTree.DescendantNodes().OfType<XmlElementSyntax>().FirstOrDefault(x => string.Equals(x.Name, elementName, StringComparison.OrdinalIgnoreCase));
                 if (element != null) {
                     var uriString = element.GetContentValue().Trim();
-                    Uri uri;
-                    if(
+                    if (
                         !Uri.IsWellFormedUriString(uriString, UriKind.Absolute) ||
-                        !Uri.TryCreate(uriString, UriKind.Absolute, out uri) ||
+                        !Uri.TryCreate(uriString, UriKind.Absolute, out Uri uri) ||
                         !uri.IsValid()
-                    ) {
-                        var range = textPositions.GetRange(element.StartTag.End, element.EndTag.Start);
-
-                        yield return new Diagnostic {
-                            Message = "Url in " + elementName + " is invalid. See https://github.com/chocolatey/package-validator/wiki/InvalidUrlProvided",
-                            Severity = DiagnosticSeverity.Error,
-                            Range = range
-                        };
+                    )
+                    {
+                        yield return CreateRequirement(
+                            element,
+                            $"Url in {elementName} is invalid.",
+                            "https://github.com/chocolatey/package-validator/wiki/InvalidUrlProvided");
                     }
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With the changes in this PR we can now rely on a base class when creating rules for nuspec files.
The base class implements a few helper functions to create diagnostics for requirements/guidelines/suggestions and notes, as well as a helper to get a single element by its name.

Changes have also been made to the existing rules to make use of the new base class.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #104 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To make it easier to implement rules.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Been tested locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality) *(I think)*
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
