### PR TITLE
(GH-38) Added choco new properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,12 @@
 							}
 						},
 						"description": "The Chocolatey Template Packages Configuration"
+					},
+					"chocolatey.new.properties": {
+						"type": "object",
+						"description": "A key value pair of properties to pass to Chocolatey when creating a new package.",
+						"uniqueItems": true,
+						"title": "New package properties"
 					}
 				}
 			}

--- a/src/ChocolateyCliManager.ts
+++ b/src/ChocolateyCliManager.ts
@@ -32,6 +32,13 @@ export class ChocolateyCliManager {
                         chocoArguments.push(`--template-name="'${template.label}'"`);
                     }
 
+                    let chocoProperties = readChocoProperties();
+                    if (chocoProperties) {
+                        for (let property of chocoProperties) {
+                            chocoArguments.push(`"${property.key}=${property.value}"`);
+                        }
+                    }
+
                     let newOp: ChocolateyOperation = new ChocolateyOperation(chocoArguments);
                     newOp.run();
                 });
@@ -40,6 +47,22 @@ export class ChocolateyCliManager {
                 newOp.run();
             }
         });
+
+        function readChocoProperties() {
+            const config = workspace.getConfiguration("chocolatey.new");
+
+            let result = new Array<{key:string,value:string}>();
+            if (config === undefined) { return result;}
+
+            const properties = config.get("properties");
+            if (properties === undefined) { return result; }
+
+            for (const key in properties) {
+                result.push({key: key, value: properties[key] });
+            }
+
+            return result;
+        }
     }
 
     public pack(): void {


### PR DESCRIPTION
This allows a user to configure common properties
to pass to choco new.

<!--- Provide a general summary of your changes in the Title above -->

## Description
The changes made in this PR involves reading a Key Value Pair in the configuration
to get common user configured properties/arguments. It iterates through any keys set in the following configuration namespace "chocolatey.new.properties", and adds all key + value when calling choco new.

## Related Issue
fixes #38 

## Motivation and Context
My main motivation for this is to not needing to configure the maintainer name every time I create a new package (as well as other properties).

## How Has This Been Tested?
It have been tested locally by creating a new package using the command, both with the properties set, and without.

## Screenshots (if appropriate):
Configuration:
![Configuration part](https://user-images.githubusercontent.com/1474648/53040224-2ce2d700-3481-11e9-89bb-5d2e564e2471.png)

After package creation:
![After Package creation](https://user-images.githubusercontent.com/1474648/53040286-56036780-3481-11e9-9caf-a63b7cca4b6d.png)

Without configuration set, and if maintainerName is set to empty:
![Without configuration](https://user-images.githubusercontent.com/1474648/53040381-8cd97d80-3481-11e9-9105-2813623b3a71.png)




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
