### PR TITLE
(GH-70) Added rule for no email validation

### DIFF
--- a/src/Chocolatey.Language.Server/Validations/CopyrightAndAuthorFieldShouldntContainEmailRequirement.cs
+++ b/src/Chocolatey.Language.Server/Validations/CopyrightAndAuthorFieldShouldntContainEmailRequirement.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Language.Xml;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using DiagnosticSeverity = OmniSharp.Extensions.LanguageServer.Protocol.Models.DiagnosticSeverity;
+
+namespace Chocolatey.Language.Server.Validations
+{
+    public sealed class CopyrightAndAuthorFieldShouldntContainEmailRequirement : NuspecRuleBase
+    {
+        // This is the same regex as used in the Package validator
+        // Known problems with this regex is it doesn't always match the whole email address.
+        private const string EmailRegexPattern = @"[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}";
+
+        private static readonly IReadOnlyList<string> ElementsToValidate = new[]
+        {
+            "copyright",
+            "authors"
+        };
+
+        private static readonly Regex _emailRegex = new Regex(EmailRegexPattern, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        /// <summary>
+        /// Runs validation of the current nuspec file by using the specified <paramref
+        /// name="syntaxTree"/> to check if author or copyright contains an email address.
+        /// </summary>
+        /// <param name="syntaxTree">The syntax tree to use during validation.</param>
+        /// <returns>An enumerable of failed checks</returns>
+        /// <seealso cref="https://github.com/chocolatey/package-validator/blob/master/src/chocolatey.package.validator/infrastructure.app/rules/CopyRightAndAuthorFieldsShouldntContainEmailRequirement.cs">
+        /// Package validator requirement for email values
+        /// </seealso>
+        public override IEnumerable<Diagnostic> Validate(XmlDocumentSyntax syntaxTree)
+        {
+            return syntaxTree.DescendantNodes()
+                .OfType<XmlElementSyntax>()
+                .Where(x => ElementsToValidate.Any(e => string.Equals(x.Name, e, StringComparison.OrdinalIgnoreCase)))
+                .SelectMany(HandleValidation);
+        }
+
+        private IEnumerable<Diagnostic> HandleValidation(XmlElementSyntax element)
+        {
+            var content = element.GetContentValue();
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return Enumerable.Empty<Diagnostic>();
+            }
+
+            var emailMatches = _emailRegex.Matches(content);
+
+            return emailMatches
+                .Where(e => e.Success)
+                .Select(e =>
+                {
+                    int start = element.StartTag.End + e.Index;
+                    int end = start + e.Length;
+                    return CreateDiagnostic(
+                        start,
+                        end,
+                        DiagnosticSeverity.Error,
+                        $"Email address should not be used in the {element.Name} field.",
+                        "https://github.com/chocolatey/package-validator/wiki/CopyrightAndAuthorFieldsShouldntContainEmail");
+                });
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The author and copyright fields is expected to not contain an email address. This commit adds the necessary validation rule to handle that check.
The implementation only highlights the offending email(s) matched by the regex.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#70 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally using my own email addresses

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
