### PR TITLE
(GH-123) First use HTTP HEAD and GET as a fallback

### DIFF
--- a/src/Chocolatey.Language.Server/UriExtensions.cs
+++ b/src/Chocolatey.Language.Server/UriExtensions.cs
@@ -12,13 +12,15 @@ namespace Chocolatey.Language.Server
         ///   Tries to validate an URL
         /// </summary>
         /// <param name="url">Uri object</param>
-        public static bool IsValid(this Uri url)
+        /// <param name="get">Bool Switch to GET request.</param>
+        public static bool IsValid(this Uri url, bool get = false)
         {
             var request = (HttpWebRequest)WebRequest.Create(url);
 
             //This would allow 301 and 302 to be valid as well
             request.AllowAutoRedirect = true;
             request.Timeout = 15000;
+            if (!get) request.Method = WebRequestMethods.Http.Head;
 
             try
             {
@@ -29,7 +31,7 @@ namespace Chocolatey.Language.Server
             }
             catch (WebException)
             {
-                return false;
+                return !get && url.IsValid(true);
             }
         }
 

--- a/src/Chocolatey.Language.Server/UriExtensions.cs
+++ b/src/Chocolatey.Language.Server/UriExtensions.cs
@@ -12,15 +12,15 @@ namespace Chocolatey.Language.Server
         ///   Tries to validate an URL
         /// </summary>
         /// <param name="url">Uri object</param>
-        /// <param name="get">Bool Switch to GET request.</param>
-        public static bool IsValid(this Uri url, bool get = false)
+        /// <param name="useGetMethod">Bool Switch to GET request.</param>
+        public static bool IsValid(this Uri url, bool useGetMethod = false)
         {
             var request = (HttpWebRequest)WebRequest.Create(url);
 
             //This would allow 301 and 302 to be valid as well
             request.AllowAutoRedirect = true;
             request.Timeout = 15000;
-            if (!get) request.Method = WebRequestMethods.Http.Head;
+            if (!useGetMethod) request.Method = WebRequestMethods.Http.Head;
 
             try
             {
@@ -31,7 +31,7 @@ namespace Chocolatey.Language.Server
             }
             catch (WebException)
             {
-                return !get && url.IsValid(true);
+                return !useGetMethod && url.IsValid(true);
             }
         }
 


### PR DESCRIPTION
Fixes #123 

This switches to HTTP HEAD requests, if that failed, it uses GET requests.