### PR TITLE
(build) Adds ability to build the language server into the extension

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,3 +24,4 @@ branches:
 cache:
 - tools -> recipe.cake
 - node_modules -> package.json
+- packages -> '**/*.csproj'

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ BuildArtifacts/
 docs/input/tasks
 tools/**
 !tools/packages.config
+packages/**
 
 # until we move to Yarn
 yarn.lock

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,4 @@ tools/**
 build/**
 build-results/**
 chocolatey/**
+packages/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -2997,8 +2997,7 @@
     "semver": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-      "dev": true
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -3974,14 +3973,12 @@
     "vscode-jsonrpc": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
-      "dev": true
+      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
     },
     "vscode-languageclient": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz",
       "integrity": "sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==",
-      "dev": true,
       "requires": {
         "semver": "^5.5.0",
         "vscode-languageserver-protocol": "3.14.1"
@@ -3991,7 +3988,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
       "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
-      "dev": true,
       "requires": {
         "vscode-jsonrpc": "^4.0.0",
         "vscode-languageserver-types": "3.14.0"
@@ -4000,8 +3996,7 @@
     "vscode-languageserver-types": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==",
-      "dev": true
+      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -149,10 +149,10 @@
 		"typemoq": "^2.1.0",
 		"typescript": "^3.3.3333",
 		"vscode": "^1.1.30",
-		"vscode-languageclient": "^5.2.1",
 		"vscode-jsonrpc": "^4.0.0"
 	},
 	"dependencies": {
+		"vscode-languageclient": "^5.2.1",
 		"xml2js": "^0.4.19"
 	},
 	"extensionPack": [

--- a/recipe.cake
+++ b/recipe.cake
@@ -27,7 +27,7 @@ Setup<DotNetCoreMSBuildSettings>((context) => {
         .WithProperty("AssemblyVersion", BuildParameters.Version.Version)
         .WithProperty("FileVersion", BuildParameters.Version.Version)
         .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion);
-    
+
     if (!IsRunningOnWindows())
     {
         var frameworkPathOverride = new FilePath(typeof(object).Assembly.Location).GetDirectory().FullPath + "/";

--- a/recipe.cake
+++ b/recipe.cake
@@ -12,4 +12,69 @@ BuildParameters.SetParameters(context: Context,
 
 BuildParameters.PrintParameters(Context);
 
+BuildParameters.Tasks.CleanTask.Does(() => {
+    var directoriesToClean = GetDirectories("./src/**/bin") +
+                             GetDirectories("./src/**/obj");
+
+    CleanDirectories(directoriesToClean);
+});
+
+const string projectFile = "./src/Chocolatey.Language.Server/Chocolatey.Language.Server.csproj";
+
+Setup<DotNetCoreMSBuildSettings>((context) => {
+    var msBuildSettings = new DotNetCoreMSBuildSettings()
+        .WithProperty("Version", BuildParameters.Version.SemVersion)
+        .WithProperty("AssemblyVersion", BuildParameters.Version.Version)
+        .WithProperty("FileVersion", BuildParameters.Version.Version)
+        .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion);
+    
+    if (!IsRunningOnWindows())
+    {
+        var frameworkPathOverride = new FilePath(typeof(object).Assembly.Location).GetDirectory().FullPath + "/";
+
+        // Use FrameworkPathOverride when not running on Windows
+        Information("Build will use FrameworkPathOverride={0} since not building on Windows.", frameworkPathOverride);
+        msBuildSettings.WithProperty("FrameworkPathOverride", frameworkPathOverride);
+    }
+
+    return msBuildSettings;
+});
+
+Task("Restore-Language-Server")
+    .IsDependentOn("Clean")
+    .Does(() => {
+        DotNetCoreRestore(projectFile, new DotNetCoreRestoreSettings {
+            // To allow caching of .net core packages
+            PackagesDirectory = "./packages"
+        });
+    });
+
+Task("Build-Language-Server")
+    .IsDependentOn("Restore-Language-Server")
+    .Does<DotNetCoreMSBuildSettings>(buildSettings =>
+{
+    DotNetCoreBuild(projectFile, new DotNetCoreBuildSettings {
+        Configuration = "Release",
+        NoIncremental = true,
+        NoRestore = true,
+        MSBuildSettings = buildSettings
+    });
+});
+
+Task("Publish-Language-Server")
+    .IsDependentOn("Build-Language-Server")
+    .Does<DotNetCoreMSBuildSettings>(buildSettings =>
+{
+    DotNetCorePublish(projectFile, new DotNetCorePublishSettings {
+        Configuration = "Release",
+        NoBuild = true,
+        NoRestore = true,
+        //SelfContained = true,
+        OutputDirectory = "./out/.server",
+        MSBuildSettings = buildSettings
+    });
+});
+
+BuildParameters.Tasks.PackageExtensionTask.IsDependentOn("Publish-Language-Server");
+
 Build.Run();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ var installed : boolean = false;
 
 const languageServerPaths = [
     // TODO: Change path to the actually expected location of the language server
-    ".server/Chocolatey.Language.Server.dll",
+    "out/.server/Chocolatey.Language.Server.dll",
     "./src/Chocolatey.Language.Server/bin/Release/netcoreapp2.1/Chocolatey.Language.Server.dll",
     "./src/Chocolatey.Language.Server/bin/Debug/netcoreapp2.1/Chocolatey.Language.Server.dll"
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the cake build script to also build the language server, which then
outputs the publishes the language server files to a path that can be used when
running the extension.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No directly related issue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Been tested locally

## Screenshots (if appropriate):
Screenshot of the embedded files inside the vsix extension
![image](https://user-images.githubusercontent.com/1474648/53681531-70dca400-3ceb-11e9-972e-593f93f0dd71.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
