### PR TITLE
(build) Added configuration to a build language server while debugging extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
-            "preLaunchTask": "npm"
+            "preLaunchTask": "Compile-Extension"
         },
         {
             "name": "Launch Tests",
@@ -22,7 +22,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
-            "preLaunchTask": "npm"
+            "preLaunchTask": "Compile-Extension"
         },
         {
             "name": "Launch Package",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,23 +8,39 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
-
-    // we want to run npm
-    "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
-
-    // we run the custom script "compile" as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
-
-    // The tsc compiler is started in watching mode
-    "isBackground": true,
-
-    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+    "version": "2.0.0",
+    
+    "tasks": [
+        {
+            "label": "Compile-Extension",
+            "command": "npm",
+            "type": "shell",
+            "args": ["run", "compile"],
+            "problemMatcher": "$tsc-watch",
+            "group": "build",
+            "dependsOn": ["Restore-NPM-Packages", "Compile-Language-Server"]
+        },
+        {
+            "label": "Restore-NPM-Packages",
+            "command": "npm",
+            "type": "shell",
+            "args": ["install", "--loglevel","silent"],
+            "problemMatcher": [ ]
+        },
+        {
+            "label": "Compile-Language-Server",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "publish",
+                "--output",
+                "${workspaceFolder}/out/.server",
+                "--configuration",
+                "Debug",
+                "${workspaceFolder}/src/Chocolatey.Language.Server"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        }
+    ]
 }

--- a/recipe.cake
+++ b/recipe.cake
@@ -20,6 +20,7 @@ BuildParameters.Tasks.CleanTask.Does(() => {
 });
 
 const string projectFile = "./src/Chocolatey.Language.Server/Chocolatey.Language.Server.csproj";
+string compileConfiguration = Argument("configuration", "Release");
 
 Setup<DotNetCoreMSBuildSettings>((context) => {
     var msBuildSettings = new DotNetCoreMSBuildSettings()
@@ -54,7 +55,7 @@ Task("Build-Language-Server")
     .Does<DotNetCoreMSBuildSettings>(buildSettings =>
 {
     DotNetCoreBuild(projectFile, new DotNetCoreBuildSettings {
-        Configuration = "Release",
+        Configuration = compileConfiguration,
         NoIncremental = true,
         NoRestore = true,
         MSBuildSettings = buildSettings
@@ -66,7 +67,7 @@ Task("Publish-Language-Server")
     .Does<DotNetCoreMSBuildSettings>(buildSettings =>
 {
     DotNetCorePublish(projectFile, new DotNetCorePublishSettings {
-        Configuration = "Release",
+        Configuration = compileConfiguration,
         NoBuild = true,
         NoRestore = true,
         //SelfContained = true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds/updates the vscode tasks to also build the Language Server (as well as restoring NPM packages) through a build command in vscode.
The launch settings have also been updated to run those build commands before launching the debugging process.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
none

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Tired of forgetting to build the language server before trying to debug the extension.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This have only been tested on Windows, as such I currently have no idea if it works on linux and MAC.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
